### PR TITLE
- Add date of each event for stalk page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ typings/
 
 # next.js build output
 .next
+
+# IntelliJ IDEA cache#
+.idea

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@types/jest": "24.0.15",
+    "@types/jest": "26.0.14",
     "@types/node": "12.0.10",
     "@types/react": "16.8.22",
     "@types/react-dom": "^16.8.4",

--- a/src/components/Stalk.tsx
+++ b/src/components/Stalk.tsx
@@ -134,19 +134,26 @@ class Stalk extends React.PureComponent<any, any> {
         const events = this.props.events ?
             this.props.events.map((el: any) => {
                 let event = null;
+                let currentDate: string = new Date(el.created_at).toDateString();
                 if (el.type === 'IssueCommentEvent') {
                     event = <Card.Grid
                         key={el.id}
                         style={{ overflow: 'hidden', width: '100%' }}
-                    ><Icon type="edit" theme="twoTone" /> Commented on the Issue in the Repository: <a href={`${el.payload.issue.html_url}`}>
-                            {el.repo.name}</a>
+                    >
+                        <Icon type="edit" theme="twoTone" />
+                        <strong> Date:  {currentDate} </strong>
+                        - Commented on the Issue in the Repository:
+                        <a href={`${el.payload.issue.html_url}`}>{el.repo.name}</a>
                     </Card.Grid>
                 } else if (el.type === 'WatchEvent') {
                     event = <Card.Grid
                         key={el.id}
                         style={{ overflow: 'hidden', width: '100%' }}
-                    > Starred<Icon type="star" theme="twoTone" twoToneColor="#ffd761" /> the Repository: <a href={`https://github.com/${el.repo.name}`}>
-                            {el.repo.name}</a>
+                    >
+                        <Icon type="star" theme="twoTone" twoToneColor="#ffd761" />
+                        <strong> Date:  {currentDate} </strong>
+                        - Starred the Repository:
+                        <a href={`https://github.com/${el.repo.name}`}>{el.repo.name}</a>
                     </Card.Grid>
                 } else if (el.type === 'IssuesEvent' && (el.payload.action === 'opened' ||
                     el.payload.action === 'closed')) {
@@ -154,9 +161,14 @@ class Stalk extends React.PureComponent<any, any> {
                         key={el.id}
                         style={{ overflow: 'hidden', width: '100%' }}
                     > {el.payload.action === 'opened'
-                        ? <><Icon type="folder-open" theme="twoTone" /> Opened an Issue in the Repository: </> : <><Icon type="close-circle" theme="twoTone" twoToneColor="red" /> Closed the Issue in the Repository: </>
-                        }<a href={`${el.payload.issue.html_url}`}>
-                            {el.repo.name}</a>
+                        ? <><Icon type="folder-open" theme="twoTone" />
+                            <strong> Date:  {currentDate} </strong>
+                            - Opened an Issue in the Repository: </>
+                        : <><Icon type="close-circle" theme="twoTone" twoToneColor="red" />
+                            <strong> Date:  {currentDate} </strong>
+                            - Closed the Issue in the Repository: </>
+                        }
+                        <a href={`${el.payload.issue.html_url}`}>{el.repo.name}</a>
                     </Card.Grid>
                 } else if (el.type === 'PullRequestEvent' && (el.payload.action === 'opened' ||
                     el.payload.action === 'closed')) {
@@ -164,37 +176,50 @@ class Stalk extends React.PureComponent<any, any> {
                         key={el.id}
                         style={{ overflow: 'hidden', width: '100%' }}
                     > {el.payload.action === 'opened'
-                        ? <><Icon type="folder-open" theme="twoTone" /> Opened a Pull Request in the Repository: </> : <><Icon type="close-circle" theme="twoTone" twoToneColor="red" /> Closed a Pull Request in the Repository: </>
-                        }<a href={`${el.payload.pull_request.html_url}`}>
-                            {el.repo.name}</a>
+                        ? <><Icon type="folder-open" theme="twoTone" />
+                            <strong> Date:  {currentDate} </strong>
+                            - Opened a Pull Request in the Repository: </>
+                        : <><Icon type="close-circle" theme="twoTone" twoToneColor="red" />
+                            <strong> Date:  {currentDate} </strong>
+                            - Closed a Pull Request in the Repository: </>
+                        }
+                        <a href={`${el.payload.pull_request.html_url}`}>{el.repo.name}</a>
                     </Card.Grid>
                 } else if (el.type === 'PushEvent') {
                     event = <Card.Grid
                         key={el.id}
                         style={{ overflow: 'hidden', width: '100%' }}
-                    ><Icon type="edit" theme="twoTone" /> Pushed a commit in the Repository: <a href={`https://github.com/${el.repo.name}`}>
-                            {el.repo.name}</a>
+                    ><Icon type="edit" theme="twoTone" />
+                        <strong> Date:  {currentDate} </strong>
+                        - Pushed a commit in the Repository:
+                        <a href={`https://github.com/${el.repo.name}`}> {el.repo.name} </a>
                     </Card.Grid>
                 } else if (el.type === 'CreateEvent') {
                     event = <Card.Grid
                         key={el.id}
                         style={{ overflow: 'hidden', width: '100%' }}
-                    ><Icon type="plus-square" theme="twoTone" twoToneColor="#42ff29" /> Created a Repository: <a href={`https://github.com/${el.repo.name}`}>
-                            {el.repo.name}</a>
+                    ><Icon type="plus-square" theme="twoTone" twoToneColor="#42ff29" />
+                        <strong> Date:  {currentDate} </strong>
+                        - Created a Repository:
+                        <a href={`https://github.com/${el.repo.name}`}>{el.repo.name}</a>
                     </Card.Grid>
                 } else if (el.type === 'PullRequestReviewEvent') {
                     event = <Card.Grid
                         key={el.id}
                         style={{ overflow: 'hidden', width: '100%' }}
-                    ><Icon type="eye" theme="twoTone" twoToneColor="#e894ff" /> Reviewed a Pull Request in the Repository: <a href={`${el.payload.pull_request.html_url}`}>
-                            {el.repo.name}</a>
+                    ><Icon type="eye" theme="twoTone" twoToneColor="#e894ff" />
+                        <strong> Date:  {currentDate} </strong>
+                        - Reviewed a Pull Request in the Repository:
+                        <a href={`${el.payload.pull_request.html_url}`}>{el.repo.name}</a>
                     </Card.Grid>
                 } else if (el.type === 'PullRequestReviewCommentEvent') {
                     event = <Card.Grid
                         key={el.id}
                         style={{ overflow: 'hidden', width: '100%' }}
-                    ><Icon type="edit" theme="twoTone" /> Commented on the Pull Request in the Repository: <a href={`${el.payload.pull_request.html_url}`}>
-                            {el.repo.name}</a>
+                    ><Icon type="edit" theme="twoTone" />
+                        <strong> Date:  {currentDate} </strong>
+                        - Commented on the Pull Request in the Repository:
+                        <a href={`${el.payload.pull_request.html_url}`}>{el.repo.name}</a>
                     </Card.Grid>
                 }
                 return ((el.type === 'PullRequestEvent' || 'WatchEvent' || 'IssuesEvent' || 'IssueCommentEvent'


### PR DESCRIPTION
This PR does 3 things:
- Adds idea generated files to the .gitignore so we can avoid unnecessary commitment of these files down the line from other devs.
- Upgrade @types/jest version - my app would not run locally otherwise.
- **Primary PR purpose**: I've added the a date before each event in the user profile page so we can see when these commits were processed. I think this would be a good addition - screenshot below!

![image](https://user-images.githubusercontent.com/21260839/94952562-136b9300-04de-11eb-8009-446c032f50ee.png)